### PR TITLE
Fix broken package on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/aarch64.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('freexl') }}
 

--- a/recipe/patches/makefile.vc.patch
+++ b/recipe/patches/makefile.vc.patch
@@ -19,7 +19,7 @@
 -		C:\OSGeo4w\lib\zlib.lib
 +		$(LIBRARY_LIB)\iconv.lib \
 +		$(LIBRARY_LIB)\libexpat.lib \
-+		$(LIBRARY_LIB)\minizip.lib
++		$(LIBRARY_LIB)\libminizip.lib
  	if exist $(FREEXL_DLL).manifest mt -manifest \
  		$(FREEXL_DLL).manifest -outputresource:$(FREEXL_DLL);2 
  


### PR DESCRIPTION
My latest pull request that got merged into master was an adaptation to make this package to work with minizip 4.0.7 that has the wrong minizip.dll.
So undo that now that the latest minizip package has restored the former libminizip.dll. Sorry for having jumped into a topic I didn't master...